### PR TITLE
ci: add Dependabot for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps-dev"
+      include: "scope"
+    groups:
+      mui:
+        patterns:
+          - "@mui/*"
+          - "@emotion/*"
+      firebase:
+        patterns:
+          - "firebase"
+          - "@firebase/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "react-router*"
+      testing:
+        patterns:
+          - "@testing-library/*"
+      dev-dependencies:
+        dependency-type: "development"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to keep dependencies up-to-date automatically
- Weekly schedule (Mondays 09:00 JST) for both npm and GitHub Actions
- Groups MUI / Firebase / React / testing-library / dev-deps to reduce PR noise
- 10 PR cap so the queue does not explode on first run

## Test plan
- [ ] Verify Dependabot runs and opens grouped PRs after merge (visible at /network/updates)
- [ ] Confirm labels (`dependencies`, `github-actions`) get applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)