### PR TITLE
ci: ignore major bumps for React/MUI/testing-library in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,26 @@ updates:
           - "@testing-library/*"
       dev-dependencies:
         dependency-type: "development"
+    ignore:
+      # Major bumps for these require coordinated migration work — handle manually.
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-router"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-router-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@mui/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@emotion/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@testing-library/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "web-vitals"
+        update-types: ["version-update:semver-major"]
+      # react-scripts (CRA) is unmaintained — pin until we migrate to Vite.
+      - dependency-name: "react-scripts"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary
Adds \`ignore\` rules to \`.github/dependabot.yml\` so Dependabot stops opening major-version PRs that require migration work:

- **React / react-dom / react-router / react-router-dom** — major bumps mean paradigm shifts (e.g. RR v7 framework mode, React 19 JSX runtime)
- **@mui/* / @emotion/*** — MUI 6/7/8/9 each have breaking changes (ESM-only, styled engine swap, theme API)
- **@testing-library/*** — major bumps require test rewrites
- **web-vitals** — API renamed (getX → onX) at v3
- **react-scripts** — CRA is unmaintained; pinned entirely until we migrate to Vite

Minor and patch updates continue to be PRed normally. Major bumps for these libraries should be done manually as a coordinated effort.

## Test plan
- [ ] After merge, confirm the closed PRs (#5, #7, #8, #10) do not get re-opened on next Dependabot run

🤖 Generated with [Claude Code](https://claude.com/claude-code)