### PR TITLE
[codex] Hide menu prices when disabled

### DIFF
--- a/src/Component/BentoSection/BentoSection.jsx
+++ b/src/Component/BentoSection/BentoSection.jsx
@@ -38,7 +38,7 @@ const BentoSection = (props) => {
         'image': bentoInfo.image,
         'price': bentoInfo.price,
         'isPriceVisibleToCustomer':
-          bentoInfo.isPriceVisibleToCustomer !== false
+          bentoInfo.isPriceVisibleToCustomer ?? true
       },
       'KARAAGE': {
         'description': karaageInfo.description,
@@ -63,16 +63,16 @@ const BentoSection = (props) => {
       <SectionTitle title="BENTO" />
       <div className={styles.bentoInfo}>
         <div className={styles.bentoImageContainer}>
-          <img src={bentoInfo?.BENTO.image} alt="Bento Image" className={styles.menuImage}
+          <img src={bentoInfo?.BENTO?.image} alt="Bento Image" className={styles.menuImage}
             onLoad={endLoading}
           />
         </div>
         <div className={styles.right}>
           <div className={styles.main}>
-            <div className={styles.title}>{bentoInfo?.BENTO.name}</div>
+            <div className={styles.title}>{bentoInfo?.BENTO?.name}</div>
             <div className={styles.price}>
-              {bentoInfo?.BENTO.isPriceVisibleToCustomer !== false &&
-                bentoInfo?.BENTO.price != null &&
+              {bentoInfo?.BENTO?.isPriceVisibleToCustomer !== false &&
+                bentoInfo?.BENTO?.price != null &&
                 `$ ${bentoInfo.BENTO.price.toFixed(2)}`}
             </div>
           </div>

--- a/src/Component/BentoSection/BentoSection.jsx
+++ b/src/Component/BentoSection/BentoSection.jsx
@@ -36,7 +36,9 @@ const BentoSection = (props) => {
       'BENTO': {
         'name': bentoInfo.title,
         'image': bentoInfo.image,
-        'price': bentoInfo.price
+        'price': bentoInfo.price,
+        'isPriceVisibleToCustomer':
+          bentoInfo.isPriceVisibleToCustomer !== false
       },
       'KARAAGE': {
         'description': karaageInfo.description,
@@ -68,7 +70,11 @@ const BentoSection = (props) => {
         <div className={styles.right}>
           <div className={styles.main}>
             <div className={styles.title}>{bentoInfo?.BENTO.name}</div>
-            <div className={styles.price}>$ {bentoInfo?.BENTO.price.toFixed(2)}</div>
+            <div className={styles.price}>
+              {bentoInfo?.BENTO.isPriceVisibleToCustomer !== false &&
+                bentoInfo?.BENTO.price != null &&
+                `$ ${bentoInfo.BENTO.price.toFixed(2)}`}
+            </div>
           </div>
           <div className={styles.contents}>
             {((width >= BREAKPOINTS.SM && width < BREAKPOINTS.MD ) ?

--- a/src/Component/MenuSection/MenuSection.jsx
+++ b/src/Component/MenuSection/MenuSection.jsx
@@ -20,7 +20,10 @@ const MenuSection = (props) => {
                 <p className={styles.title}>{menu.title}</p>
                 <p className={styles.subTitle}>{menu.subTitle}</p>
               </div>
-              <div className={styles.price}>$ {menu.price.toFixed(2)}</div>
+              <div className={styles.price}>
+                {menu.isPriceVisibleToCustomer !== false &&
+                  `$ ${menu.price.toFixed(2)}`}
+              </div>
             </div>
             <div className={styles.subSection}>
               <div className={styles.description}>{menu.description}</div>

--- a/src/Component/MenuSection/MenuSection.jsx
+++ b/src/Component/MenuSection/MenuSection.jsx
@@ -22,6 +22,7 @@ const MenuSection = (props) => {
               </div>
               <div className={styles.price}>
                 {menu.isPriceVisibleToCustomer !== false &&
+                  menu.price != null &&
                   `$ ${menu.price.toFixed(2)}`}
               </div>
             </div>

--- a/src/Component/MenuSection/MenuSectionWithoutImage.jsx
+++ b/src/Component/MenuSection/MenuSectionWithoutImage.jsx
@@ -19,7 +19,10 @@ const MenuSectionWithoutImage = (props) => {
                 <p className={styles.title}>{menu.title}</p>
                 <SubTitle subTitle={menu.subTitle} />
               </div>
-              <div className={styles.price}>$ {menu.price.toFixed(2)}</div>
+              <div className={styles.price}>
+                {menu.isPriceVisibleToCustomer !== false &&
+                  `$ ${menu.price.toFixed(2)}`}
+              </div>
             </div>
             {/* <hr className="solid" /> */}
             <div className={styles.subSection}>

--- a/src/Component/MenuSection/MenuSectionWithoutImage.jsx
+++ b/src/Component/MenuSection/MenuSectionWithoutImage.jsx
@@ -21,6 +21,7 @@ const MenuSectionWithoutImage = (props) => {
               </div>
               <div className={styles.price}>
                 {menu.isPriceVisibleToCustomer !== false &&
+                  menu.price != null &&
                   `$ ${menu.price.toFixed(2)}`}
               </div>
             </div>

--- a/src/Firebase/menu.js
+++ b/src/Firebase/menu.js
@@ -23,6 +23,8 @@ export const getPublicMenuList = async () => {
       description: menuDoc.data().description,
       ingredients: menuDoc.data().ingredients,
       image: menuDoc.data().image,
+      isPriceVisibleToCustomer:
+        menuDoc.data().isPriceVisibleToCustomer !== false,
       isAvailable: menuDoc.data().isAvailable,
       order: menuDoc.data().order, // order of the food displayed
       originalStockCount: menuDoc.data().originalStockCount,
@@ -50,6 +52,8 @@ export const getMenuList = async () => {
       ingredients: menuDoc.data().ingredients,
       image: menuDoc.data().image,
       isVisibleToCustomer: menuDoc.data().isVisibleToCustomer,
+      isPriceVisibleToCustomer:
+        menuDoc.data().isPriceVisibleToCustomer !== false,
       isAvailable: menuDoc.data().isAvailable,
       order: menuDoc.data().order, // order of the food displayed
       originalStockCount: menuDoc.data().originalStockCount,

--- a/src/Firebase/menu.js
+++ b/src/Firebase/menu.js
@@ -13,18 +13,18 @@ export const getPublicMenuList = async () => {
   const querySnapshot = await getDocs(q);
   for (let i = 0; i < querySnapshot.docs.length; i++) {
     const menuDoc = querySnapshot.docs[i];
+    const isPriceVisibleToCustomer =
+      menuDoc.data().isPriceVisibleToCustomer ?? true;
     const menu = {
       id: menuDoc.id,
       title: menuDoc.data().title,
       subTitle: menuDoc.data().subTitle,
       type: menuDoc.data().type,
-      price: menuDoc.data().price,
-      cost: menuDoc.data().cost,
+      price: isPriceVisibleToCustomer ? menuDoc.data().price : null,
       description: menuDoc.data().description,
       ingredients: menuDoc.data().ingredients,
       image: menuDoc.data().image,
-      isPriceVisibleToCustomer:
-        menuDoc.data().isPriceVisibleToCustomer !== false,
+      isPriceVisibleToCustomer,
       isAvailable: menuDoc.data().isAvailable,
       order: menuDoc.data().order, // order of the food displayed
       originalStockCount: menuDoc.data().originalStockCount,
@@ -53,7 +53,7 @@ export const getMenuList = async () => {
       image: menuDoc.data().image,
       isVisibleToCustomer: menuDoc.data().isVisibleToCustomer,
       isPriceVisibleToCustomer:
-        menuDoc.data().isPriceVisibleToCustomer !== false,
+        menuDoc.data().isPriceVisibleToCustomer ?? true,
       isAvailable: menuDoc.data().isAvailable,
       order: menuDoc.data().order, // order of the food displayed
       originalStockCount: menuDoc.data().originalStockCount,


### PR DESCRIPTION
## Summary

Honors the menu item's `isPriceVisibleToCustomer` flag on the customer-facing site.

- Reads `isPriceVisibleToCustomer` from Firestore with backward-compatible default visibility.
- Leaves price space blank when the flag is disabled.
- Applies the behavior to regular menu cards, menu cards without images, and the Bento section.

## Impact

Customers will no longer see prices for menu items that admins mark as hidden, while existing items continue to show prices until changed.

## Validation

- `npm run build`